### PR TITLE
feat(time): configurable main loop check interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ This project is in a very early stage of development. It is not recommended to u
 - [ ] gke-preemptible-sniper 0.2.0:
   - [x] allowlist hours
   - [x] blocklist hours
-  - configurable check interval
+  - [x] configurable check interval
   - configurable node drain timeout
 
 - [ ] gke-preemptible-sniper 0.3.0:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -24,6 +25,8 @@ var ready bool
 
 var allowedTimes timing.TimeSlots
 var blockedTimes timing.TimeSlots
+
+var checkInterval int
 
 func init() {
 	logger = slog.New(slog.NewJSONHandler(os.Stdout, nil))
@@ -66,6 +69,16 @@ func init() {
 			logger.Error("failed to parse BLOCKED_HOURS", "error", err)
 			os.Exit(6)
 		}
+	}
+
+	checkIntervalStr := os.Getenv("CHECK_INTERVAL_SECONDS")
+	checkInterval, err := strconv.Atoi(checkIntervalStr)
+	if err != nil {
+		logger.Error("failed to parse CHECK_INTERVAL_SECONDS", "error", err)
+		os.Exit(7)
+	}
+	if checkInterval == 0 {
+		checkInterval = 300
 	}
 
 	healthy = true
@@ -201,6 +214,6 @@ func main() {
 			}
 		}
 		cancel()
-		time.Sleep(300 * time.Second)
+		time.Sleep(time.Duration(checkInterval) * time.Second)
 	}
 }

--- a/helm/gke-preemptible-sniper/templates/deployment.yaml
+++ b/helm/gke-preemptible-sniper/templates/deployment.yaml
@@ -49,3 +49,5 @@ spec:
               value: {{ .Values.time.allowList }}
             - name: BLOCKED_HOURS
               value: {{ .Values.time.blockList }}
+            - name: CHECK_INTERVAL_SECONDS
+              value: {{ .Values.time.checkIntervalSeconds }}

--- a/helm/gke-preemptible-sniper/values.yaml
+++ b/helm/gke-preemptible-sniper/values.yaml
@@ -64,7 +64,8 @@ readinessProbe:
     path: /readyz
     port: http
 
-# by default, gke-preemptible-sniper will be allowed to run at any time
+# by default, gke-preemptible-sniper will be allowed to run at any time and will check every 5 minutes
 time:
   allowList: "00:00-23:59"
   blockList: ""
+  checkIntervalSeconds: 300


### PR DESCRIPTION
Make check interval configurable.

Currently, the main loop runs every 5 minutes and is not configurable. Users might want to override this in several cases.