### PR TITLE
feat(core): configurable node drain timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ This project is in a very early stage of development. It is not recommended to u
   - [x] Helm Chart
   - [x] GitHub Actions Build
 
-- [ ] gke-preemptible-sniper 0.2.0:
+- [x] gke-preemptible-sniper 0.2.0:
   - [x] allowlist hours
   - [x] blocklist hours
   - [x] configurable check interval
-  - configurable node drain timeout
+  - [x] configurable node drain timeout
 
 - [ ] gke-preemptible-sniper 0.3.0:
   - provide prometheus metrics

--- a/helm/gke-preemptible-sniper/Chart.yaml
+++ b/helm/gke-preemptible-sniper/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: gke-preemptible-sniper
 description: A Kubernetes controller to spread preemption for preemtible VMs in GKE to avoid mass deletion after 24 hours. In respect to `estafette-gke-preemptible-killer`.
 type: application
-version: 0.1.3
+version: 0.2.0
 appVersion: "6ba3040"

--- a/helm/gke-preemptible-sniper/templates/deployment.yaml
+++ b/helm/gke-preemptible-sniper/templates/deployment.yaml
@@ -51,3 +51,5 @@ spec:
               value: {{ .Values.time.blockList }}
             - name: CHECK_INTERVAL_SECONDS
               value: {{ .Values.time.checkIntervalSeconds }}
+            - name: NODE_DRAIN_TIMEOUT_SECONDS
+              value: {{ .Values.time.nodeDrainTimeoutSeconds }}

--- a/helm/gke-preemptible-sniper/values.yaml
+++ b/helm/gke-preemptible-sniper/values.yaml
@@ -68,4 +68,5 @@ readinessProbe:
 time:
   allowList: "00:00-23:59"
   blockList: ""
-  checkIntervalSeconds: 300
+  checkIntervalSeconds: 1200
+  nodeDrainTimeoutSeconds: 300


### PR DESCRIPTION
Configurable node drain timeout, defaults to 300s.

Raised main loop occurance to 1200s.

This will modify the behavior of `gke-preemptible-sniper` to run the main event loop every 20 minutes, and give time for up to 4 node drains to happen in this time slot.

In case of timeout after 5 minutes / 20 minutes, the next main event loop will catch up with the operation.

Strategically, it's quite good that the node gets cordoned first, so nothing comes close afterwards.

I will have to play around with the numbers soon.