### PR TITLE
ci(gh-actions): move from state outputs to new patched version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         id: check
         run: |
           if [[ "${{ needs.unittest.outputs.test-result }}" == "success" ]]; then
-            echo "::set-output name=result::success"
+            echo "result==success" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=result::failure"
+            echo "result==failure" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -26,4 +26,4 @@ jobs:
         id: test
         run: |
           make test
-          echo "::set-output name=result::success"
+          echo "result==success" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Apparently, saving pipeline state to output is deprecated and will be removed soon. This PR implements the new way of saving pipeline state.